### PR TITLE
HBSD: Fix build of hardenedbsd/secadm

### DIFF
--- a/hardenedbsd/secadm/Makefile
+++ b/hardenedbsd/secadm/Makefile
@@ -16,7 +16,9 @@ USE_GITLAB=	yes
 GL_SITE=	https://git.hardenedbsd.org
 GL_ACCOUNT=	hardenedbsd
 GL_PROJECT=	secadm
-GL_COMMIT=	fea76e9d1d05c41fa475f261359d5acf406d50e7
+GL_TAGNAME=	fea76e9d1d05c41fa475f261359d5acf406d50e7
+
+MAKE_ARGS+=	MANDIR=${PREFIX}/share/man/man
 
 .if !defined(KMOD)
 LIBDIR?=	${PREFIX}/lib

--- a/hardenedbsd/secadm/pkg-plist
+++ b/hardenedbsd/secadm/pkg-plist
@@ -2,6 +2,6 @@ etc/rc.d/secadm
 include/secadm.h
 lib/libsecadm.so
 lib/libsecadm.so.1
-man/man5/secadm.rules.5.gz
-man/man8/secadm.8.gz
+share/man/man5/secadm.rules.5.gz
+share/man/man8/secadm.8.gz
 sbin/secadm


### PR DESCRIPTION
### Fixed
- [SECADM] Documentation has been moved to **${PREFIX}/share/man** to follow freebsd's recommendations