### PR TITLE
HBSD: Fix ignore condition in kmod.mk

### DIFF
--- a/Mk/Uses/kmod.mk
+++ b/Mk/Uses/kmod.mk
@@ -19,7 +19,7 @@ _DEBUG_KMOD=	yes
 IGNORE=	USES=kmod takes either no arguments or 'debug'
 .  endif
 
-.  if !exists(${SRC_BASE}/sys/Makefile) && target(build)
+.  if !exists(${SRC_BASE}/sys/Makefile) && (target(build) || target(pre-build))
 IGNORE=	requires kernel source files in SRC_BASE=${SRC_BASE}
 .  endif
 


### PR DESCRIPTION
### Fixed
- [KMOD.MK] Ignore condition not properly triggered if source tree does not exist